### PR TITLE
Remove override of AutoCommit

### DIFF
--- a/kamux.go
+++ b/kamux.go
@@ -112,8 +112,6 @@ func NewKamux(config *Config) (kamux *Kamux, err error) {
 	kamux.ConsumerConfig.Net.SASL.Password = kamux.Config.Password
 	kamux.ConsumerConfig.Net.TLS.Enable = true
 	kamux.ConsumerConfig.Consumer.Return.Errors = true
-	// If the user wants kamux to mark offsets after message handling, disable consumer autocommit
-	kamux.ConsumerConfig.Consumer.Offsets.AutoCommit.Enable = !kamux.Config.MarkOffsets
 	kamux.globalLock = new(sync.RWMutex)
 
 	// Force kafka version


### PR DESCRIPTION
`session.MarkMessage` does not commit, it update the internal offset of the `PartitionOffsetManager` of your topic. Then, asynchronously, a goroutine comes every second and commit the offset to Kafka.

> 	// Note: calling MarkOffset does not necessarily commit the offset to the backend
	// store immediately for efficiency reasons, and it may never be committed if
	// your application crashes. This means that you may end up processing the same
	// message twice, and your processing should ideally be idempotent.

MarkOffset is called by MarkMessage.